### PR TITLE
Small fixes to top level Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,17 +16,14 @@ clone_all: clone_OpenROAD $(addprefix clone_,$(OPENROAD_MODULES))
 	@
 
 clone_OpenROAD:
-	git submodule init
-	git submodule update --recursive
+	git submodule update --init --recursive
 	
 	# --recursive doesn't recurse all the way
 	cd OpenROAD && \
-	git submodule init && \
-	git submodule update --recursive
+	git submodule update --init --recursive
 	
 	cd $(SRC_PATH)/OpenDB && \
-	git submodule init && \
-	git submodule update --recursive 
+	git submodule update --init --recursive
 
 clone_yosys:
 	if ! [ -d $(SRC_PATH)/yosys ]; then \

--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,8 @@ clone_yosys:
 
 clone_TritonRoute:
 	if ! [ -d $(SRC_PATH)/TritonRoute ]; then \
-		git clone --recursive git@github.com:The-OpenROAD-Project/TritonRoute.git $(SRC_PATH)/TritonRoute; \
+		git clone --recursive git@github.com:The-OpenROAD-Project/TritonRoute.git $(SRC_PATH)/TritonRoute --branch alpha2; \
 	fi
-	cd $(SRC_PATH)/TritonRoute && \
-	git checkout alpha2
 
 docker_%: clone_%
 	docker build -t openroad/$(shell echo $* | tr A-Z a-z) -f $(SRC_PATH)/$*/Dockerfile $(SRC_PATH)/$*


### PR DESCRIPTION
 * Clone the correct branch directly for OpenTriton.
 * Use `--init` in submodule commands.