### PR TITLE
Remove ABC SDC constraint

### DIFF
--- a/flow/scripts/synth.tcl
+++ b/flow/scripts/synth.tcl
@@ -8,8 +8,7 @@ if {[info exist ::env(DC_NETLIST)]} {
 # Don't change these unless you know what you are doing
 set stat_ext    "_stat.rep"
 set gl_ext      "_gl.v"
-set abc_script  "+read_constr,$::env(SDC_FILE);strash;ifraig;dc2;fraig;rewrite;refactor;resub;rewrite;refactor;resub;rewrite;rewrite,-z;rewrite,-z;rewrite,-z;balance;refactor,-z;refactor,-N,11;resub,-K,10;resub,-K,12;resub,-K,14;resub,-K,16;refactor;balance;map,-a;topo;dnsize;buffer,-p;upsize;"
-#set abc_script  "+read_constr,$::env(SDC_FILE);strash;ifraig;retime,-D,{D},-M,6;strash;dch,-f;map,-p,-M,1,{D},-f;topo;dnsize;buffer,-p;upsize;"
+set abc_script  "+strash;ifraig;dc2;fraig;rewrite;refactor;resub;rewrite;refactor;resub;rewrite;rewrite,-z;rewrite,-z;rewrite,-z;balance;refactor,-z;refactor,-N,11;resub,-K,10;resub,-K,12;resub,-K,14;resub,-K,16;refactor;balance;map,-a;topo;dnsize;buffer,-p;upsize;"
 
 
 # Setup verilog include directories
@@ -69,7 +68,6 @@ opt
 
 # Technology mapping for cells
 abc -D [expr $::env(CLOCK_PERIOD) * 1000] \
-    -constr "$::env(SDC_FILE)" \
     -liberty $::env(OBJECTS_DIR)/merged.lib \
     -script $abc_script \
     -showtmp


### PR DESCRIPTION
flow/scripts/synth.tcl
  - Remove SDC constraint
  - ABC does not effectively do anything with the SDC except issue errors
  - ABC has limited ability to understand complex SDCs, so it is more effective
    to remove it than to fix it